### PR TITLE
Dp 755

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -123,6 +124,12 @@
       <groupId>com.google.cloud.dataflow</groupId>
       <artifactId>google-cloud-dataflow-java-sdk-all</artifactId>
       <version>1.9.0</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>httpclient</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
exclude httpclient from dataflow 1.9.0 add version to maven-compiler-plugin to stop warnings.

When running a pipeline that has httpcomponents dependency there is a classpath error due duplicate dependencies with different versions.

Exclude the httpcomponents dataflow dependency and rely on providing the up to date one in the pipeline.

Minor addition of `version` to maven-shader-plugin to remove the warnings when `mvn package`ing
